### PR TITLE
Update auther, homepage, repo, issue page and name space

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "truffle",
   "description": "Truffle - Simple development framework for Ethereum",
-  "author": "consensys.net",
-  "homepage": "https://github.com/trufflesuite/truffle/",
-  "repository": "https://github.com/trufflesuite/truffle/tree/master/packages/truffle",
+  "author": "PlatONnetwork",
+  "homepage": "https://www.platon.network/en",
+  "repository": "https://github.com/PlatONnetwork/platon-truffle",
   "bugs": {
-    "url": "https://github.com/trufflesuite/truffle/issues"
+    "url": "https://github.com/PlatONnetwork/platon-truffle/issues"
   },
   "version": "5.1.2",
   "main": "./build/library.bundled.js",
@@ -66,6 +66,5 @@
       "email": "tim@timothyjcoulter.com",
       "url": "https://github.com/tcoulter"
     }
-  ],
-  "namespace": "consensys"
+  ]
 }


### PR DESCRIPTION
## Current

Currently, if you go to our repo package on npmjs, the information is not correct. eg. repo is pointing to truffle original repo.

## Expect

Correct information provided by the `package.json`, which will also fix the incorrect information under npmjs page.